### PR TITLE
Update/lock docker-compose image reference digests

### DIFF
--- a/Dockerfile.devtools
+++ b/Dockerfile.devtools
@@ -1,4 +1,4 @@
-FROM golang:1.17.8-buster@sha256:267cd0d6449f47031b4a6b386e5652ee572ced4ee7e2ec846352b0132bf0d3e5
+FROM golang:1.17.8-buster@sha256:8b47df92d895fe5357c7fc1ee024a7730a48966f31bd1c23481866abf3bf8e26
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 


### PR DESCRIPTION

Update or lock docker image reference digests in docker-compose files.

**IMPORTANT**: This PR is made by a script, please merge after approving.
