### PR TITLE
Remove `CODEOWNERS`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,0 @@
-*       @coopnorge/engineering
-/CODEOWNERS @coopnorge/security-guild
-
-.github/workflows/security-* @coopnorge/security-guild


### PR DESCRIPTION
`CODEOWNERS` are replaced by policy bot
