### PR TITLE
chore(ci): Remove validation against old go versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,27 +42,9 @@ jobs:
       - name: Validate
         run: docker compose run --rm ${{ env.docker-compose-service }} validate VERBOSE=all
 
-  validate-old-go:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go: [ '1.20', '1.21' ]
-    name: Go ${{ matrix.go }} - validate
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ matrix.go }}
-      - name: Install toolchain
-        run: make toolchain
-      - name: Validate
-        run: make validate
-
   build:
     needs:
       - golang-ci
-      - validate-old-go
     if: always()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
We only support the 2 latest versions of Go, validating we golang
devtools should be enough. If we need to validate against multiple
versions of Go we should implement that in `golang-devtools`.