### PR TITLE
docs(readme): Update branch status badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Masker library for Go
 
 
-![branch status](https://github.com/coopnorge/go-masker-lib/actions/workflows/pr.yaml/badge.svg?branch=main)
+![branch status](https://github.com/coopnorge/go-masker-lib/actions/workflows/ci.yaml/badge.svg?branch=main)
 
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/coopnorge/go-masker-lib)](https://goreportcard.com/report/github.com/coopnorge/go-masker-lib)


### PR DESCRIPTION
The URL for the CI badge in the README is still pointing to the old workflow name, which is causing a broken badge.

The workflow was renamed from pr -> ci in a previous PR. 

This PR just updates the URL to the correct one.